### PR TITLE
Fix MySQL connector version

### DIFF
--- a/ranger-admin/install.properties
+++ b/ranger-admin/install.properties
@@ -35,7 +35,7 @@ DB_FLAVOR=MYSQL
 #SQL_CONNECTOR_JAR=/usr/share/java/postgresql.jar
 #SQL_CONNECTOR_JAR=/usr/share/java/sqljdbc4.jar
 #SQL_CONNECTOR_JAR=/opt/sqlanywhere17/java/sajdbc4.jar
-SQL_CONNECTOR_JAR=/opt/mysql-connector-java-8.0.21.jar
+SQL_CONNECTOR_JAR=/opt/mysql-connector-java-8.0.26.jar
 
 
 #


### PR DESCRIPTION
Fix error when running ranger container about which mysql connector is used.
Previously the Dockerfile had been updated but not the **install.properties**.